### PR TITLE
Fix derive highlighting

### DIFF
--- a/starchart-derive/src/lib.rs
+++ b/starchart-derive/src/lib.rs
@@ -22,7 +22,10 @@ const ID_IDENT: &str = "id";
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
-use syn::{Attribute, Data, DeriveInput, Error, Field, Fields, Ident, Result, Type, parse_macro_input, spanned::Spanned};
+use syn::{
+    parse_macro_input, spanned::Spanned, Attribute, Data, DeriveInput, Error, Field, Fields, Ident,
+    Result, Type,
+};
 
 #[proc_macro_derive(Key, attributes(key))]
 pub fn derive_key(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/starchart-derive/src/lib.rs
+++ b/starchart-derive/src/lib.rs
@@ -21,10 +21,8 @@ const KEY_IDENT: &str = "key";
 const ID_IDENT: &str = "id";
 
 use proc_macro2::{Span, TokenStream};
-use quote::quote;
-use syn::{
-    parse_macro_input, Attribute, Data, DeriveInput, Error, Field, Fields, Ident, Result, Type,
-};
+use quote::{quote, quote_spanned};
+use syn::{Attribute, Data, DeriveInput, Error, Field, Fields, Ident, Result, Type, parse_macro_input, spanned::Spanned};
 
 #[proc_macro_derive(Key, attributes(key))]
 pub fn derive_key(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -69,18 +67,20 @@ fn parse(input: DeriveInput) -> Result<TokenStream> {
         }
     };
 
-    let id_field_ident = match &id_field.ident {
+    let id_ident = match &id_field.ident {
         None => return Err(Error::new_spanned(id_field, "expected a named field")),
         Some(f) => f,
     };
 
     let id_type = &id_field.ty;
 
-    let implementation = quote! {
+    let id_span = id_field.span();
+
+    let implementation = quote_spanned! {id_span=>
         #[automatically_derived]
         impl ::starchart::Key for #ident {
             fn to_key(&self) -> std::string::String {
-                <#id_type as ::std::string::ToString>::to_string(&self.#id_field_ident)
+                <#id_type as ::std::string::ToString>::to_string(&self.#id_ident)
             }
         }
     };


### PR DESCRIPTION
Fixes the highlighting for when the key macro is used and an incorrect field type is used, and will highlight the offending field directly instead of the derive macro