### PR TITLE
Feat: metadata

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           command: doc
           args: --workspace --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: --cfg docsrs -D rustdoc::broken_intra_doc_links
 
       - name: Cache docs
         uses: actions/cache@v2

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -264,11 +264,6 @@ jobs:
         with:
           crate: xargo
 
-      - name: Run cargo clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
-
       - name: Run Miri UB check
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,9 +68,10 @@ lto = "fat"
 
 [features]
 cache = ["serde-value"]
-default = ["json"]
+default = ["json", "metadata"]
 derive = ["starchart-derive"]
 fs = ["tokio", "tokio-stream"]
+metadata = []
 json = ["serde_json", "fs"]
 
 [workspace]

--- a/src/action/error.rs
+++ b/src/action/error.rs
@@ -34,6 +34,11 @@ pub enum ActionValidationError {
 	/// No table was provided.
 	#[error("no table was provided")]
 	Table,
+	/// A provided key or table name was "metadata", which is restricted
+	#[cfg(feature = "metadata")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "metadata")))]
+	#[error("the `metadata` key is restricted")]
+	Metadata
 }
 
 /// An error that occurred from running an [`Action`].

--- a/src/action/error.rs
+++ b/src/action/error.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::{error::Error, fmt::Debug};
 
 use thiserror::Error;
 
@@ -37,7 +37,7 @@ pub enum ActionValidationError {
 	/// A provided key or table name was "metadata", which is restricted
 	#[cfg(feature = "metadata")]
 	#[cfg_attr(docsrs, doc(cfg(feature = "metadata")))]
-	#[error("the `metadata` key is restricted")]
+	#[error("the `__metadata__` key is restricted")]
 	Metadata,
 }
 
@@ -45,10 +45,17 @@ pub enum ActionValidationError {
 ///
 /// [`Action`]: crate::action::Action
 #[derive(Debug, Error)]
-#[error("an error occurred running the action")]
 pub enum ActionRunError<E: Error> {
 	/// An error occurred from the [`Backend`].
 	///
 	/// [`Backend`]: crate::backend::Backend
+	#[error(transparent)]
 	Backend(#[from] E),
+	/// An invalid [`Entry`] was provided.
+	///
+	/// [`Entry`]: crate::Entry
+	#[cfg(feature = "metadata")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "metadata")))]
+	#[error("invalid entry was provided, {0} does not match the metadata for table `{1}`")]
+	Metadata(&'static str, String),
 }

--- a/src/action/error.rs
+++ b/src/action/error.rs
@@ -38,7 +38,7 @@ pub enum ActionValidationError {
 	#[cfg(feature = "metadata")]
 	#[cfg_attr(docsrs, doc(cfg(feature = "metadata")))]
 	#[error("the `metadata` key is restricted")]
-	Metadata
+	Metadata,
 }
 
 /// An error that occurred from running an [`Action`].

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -31,7 +31,7 @@ pub use self::{
 };
 use crate::{backend::Backend, util::InnerUnwrap, Entry, Gateway, IndexEntry, Key};
 
-#[cfg(feature = "metadata")]
+#[cfg(all(feature = "metadata", not(tarpaulin_include)))]
 const METADATA_KEY: &str = "__metadata__";
 
 /// A type alias for an [`Action`] with [`CreateOperation`] and [`EntryTarget`] as the parameters.
@@ -174,13 +174,13 @@ impl<S: Entry, C: CrudOperation, T: OpTarget> Action<S, C, T> {
 			return Err(ActionValidationError::Table);
 		}
 
-		#[cfg(feature = "metadata")] // coverage:ignore-line
+		#[cfg(all(feature = "metadata", not(tarpaulin_include)))] // coverage:ignore-line
 		self.validate_metadata(self.table.as_deref())?;
 
 		Ok(())
 	}
 
-	#[cfg(feature = "metadata")]
+	#[cfg(all(feature = "metadata", not(tarpaulin_include)))]
 	fn validate_metadata(&self, key: Option<&str>) -> Result<(), ActionValidationError> {
 		if key == Some(METADATA_KEY) {
 			return Err(ActionValidationError::Metadata);
@@ -218,7 +218,7 @@ impl<S: Entry, C: CrudOperation> Action<S, C, EntryTarget> {
 			return Err(ActionValidationError::Key);
 		}
 
-		#[cfg(feature = "metadata")] // coverage:ignore-line
+		#[cfg(all(feature = "metadata", not(tarpaulin_include)))] // coverage:ignore-line
 		self.validate_metadata(self.key.as_deref())?;
 
 		Ok(())
@@ -396,7 +396,7 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, (), ActionRunError<B::Error
 				return Ok(());
 			}
 
-			#[cfg(feature = "metadata")]
+			#[cfg(all(feature = "metadata", not(tarpaulin_include)))]
 			{
 				backend
 					.get::<S>(&table_name, &METADATA_KEY)
@@ -434,7 +434,7 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, Option<S>, ActionRunError<B
 
 			let backend = gateway.backend();
 
-			#[cfg(feature = "metadata")]
+			#[cfg(all(feature = "metadata", not(tarpaulin_include)))]
 			{
 				backend
 					.get::<S>(&table_name, &METADATA_KEY)
@@ -471,7 +471,7 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, (), ActionRunError<B::Error
 
 			let backend = gateway.backend();
 
-			#[cfg(feature = "metadata")]
+			#[cfg(all(feature = "metadata", not(tarpaulin_include)))]
 			{
 				backend
 					.get::<S>(&table, &METADATA_KEY)
@@ -543,7 +543,7 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, Vec<S>, ActionRunError<B::E
 
 			let backend = gateway.backend();
 
-			#[cfg(feature = "metadata")]
+			#[cfg(all(feature = "metadata", not(tarpaulin_include)))]
 			{
 				backend
 					.get::<S>(&table, &METADATA_KEY)
@@ -589,7 +589,7 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, (), ActionRunError<B::Error
 
 			backend.ensure_table(&table).await?;
 
-			#[cfg(feature = "metadata")]
+			#[cfg(all(feature = "metadata", not(tarpaulin_include)))]
 			{
 				let metadata = S::default();
 				backend.ensure(&table, &METADATA_KEY, &metadata).await?;

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -543,14 +543,15 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, Vec<S>, ActionRunError<B::E
 			#[cfg(all(feature = "metadata", not(tarpaulin_include)))] // coverage:ignore-line
 			self.check_metadata(backend, &table).await?;
 
-			// coverage:ignore-start
-			let keys = backend
-				.get_keys::<Vec<_>>(&table)
-				.await?
-				.into_iter()
-				.filter(|value| value != METADATA_KEY)
-				.collect::<Vec<_>>();
-			// coverage:ignore-end
+			#[cfg(not(tarpaulin_include))] // coverage:ignore-line
+			let keys = {
+				backend
+					.get_keys::<Vec<_>>(&table)
+					.await?
+					.into_iter()
+					.filter(|value| value != METADATA_KEY)
+					.collect::<Vec<_>>()
+			};
 
 			let keys_borrowed = keys.iter().map(String::as_str).collect::<Vec<_>>();
 

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -533,6 +533,7 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, bool, ActionRunError<B::Err
 impl<B: Backend, S: Entry + 'static> ActionRunner<B, Vec<S>, ActionRunError<B::Error>>
 	for Action<S, ReadOperation, TableTarget>
 {
+	#[cfg(not(tarpaulin_include))]
 	unsafe fn run(self, gateway: &Gateway<B>) -> ActionRunFuture<'_, Vec<S>, B> {
 		let lock = gateway.guard.read();
 		let res = Box::pin(async move {
@@ -543,7 +544,6 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, Vec<S>, ActionRunError<B::E
 			#[cfg(all(feature = "metadata", not(tarpaulin_include)))] // coverage:ignore-line
 			self.check_metadata(backend, &table).await?;
 
-			#[cfg(not(tarpaulin_include))] // coverage:ignore-line
 			let keys = {
 				backend
 					.get_keys::<Vec<_>>(&table)

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -9,7 +9,6 @@ mod target;
 
 use std::{
 	any::type_name,
-	error::Error,
 	fmt::{Debug, Formatter, Result as FmtResult},
 	future::Future,
 	marker::PhantomData,

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -544,14 +544,12 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, Vec<S>, ActionRunError<B::E
 			#[cfg(all(feature = "metadata", not(tarpaulin_include)))] // coverage:ignore-line
 			self.check_metadata(backend, &table).await?;
 
-			let keys = {
-				backend
-					.get_keys::<Vec<_>>(&table)
-					.await?
-					.into_iter()
-					.filter(|value| value != METADATA_KEY)
-					.collect::<Vec<_>>()
-			};
+			let keys = backend
+				.get_keys::<Vec<_>>(&table)
+				.await?
+				.into_iter()
+				.filter(|value| value != METADATA_KEY)
+				.collect::<Vec<_>>();
 
 			let keys_borrowed = keys.iter().map(String::as_str).collect::<Vec<_>>();
 

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -397,6 +397,10 @@ impl<S: Entry, C: CrudOperation, T: OpTarget> Default for Action<S, C, T> {
 	}
 }
 
+unsafe impl<S: Entry + Send, C: CrudOperation, T: OpTarget> Send for Action<S, C, T> {}
+
+unsafe impl<S: Entry + Sync, C: CrudOperation, T: OpTarget> Sync for Action<S, C, T> {}
+
 impl<B: Backend, S: Entry + 'static> ActionRunner<B, (), ActionRunError<B::Error>>
 	for Action<S, CreateOperation, EntryTarget>
 {

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -170,6 +170,18 @@ impl<S: Entry, C: CrudOperation, T: OpTarget> Action<S, C, T> {
 			return Err(ActionValidationError::Table);
 		}
 
+		#[cfg(feature = "metadata")] // coverage:ignore-line
+		self.validate_metadata(self.table.as_deref())?;
+
+		Ok(())
+	}
+
+	#[cfg(feature = "metadata")]
+	fn validate_metadata(&self, key: Option<&str>) -> Result<(), ActionValidationError> {
+		if key == Some("metadata") {
+			return Err(ActionValidationError::Metadata);
+		}
+
 		Ok(())
 	}
 }
@@ -201,6 +213,9 @@ impl<S: Entry, C: CrudOperation> Action<S, C, EntryTarget> {
 		if self.key.is_none() {
 			return Err(ActionValidationError::Key);
 		}
+
+		#[cfg(feature = "metadata")] // coverage:ignore-line
+		self.validate_metadata(self.key.as_deref())?;
 
 		Ok(())
 	}
@@ -576,7 +591,7 @@ impl<B: Backend, S: Entry + 'static> ActionRunner<B, bool, ActionRunError<B::Err
 	}
 }
 
-#[cfg(all(test, feature = "cache"))]
+#[cfg(all(test, feature = "cache", feature = "metadata"))]
 mod tests {
 	use serde::{Deserialize, Serialize};
 
@@ -786,6 +801,12 @@ mod tests {
 		assert!(action.validate_data().is_err());
 		action.set_data(&Settings::default());
 		assert!(action.validate_data().is_ok());
+
+		action.set_key(&"metadata");
+		assert!(action.validate_key().is_err());
+
+		action.set_table("metadata");
+		assert!(action.validate_table().is_err());
 
 		Ok(())
 	}

--- a/src/backend/cache.rs
+++ b/src/backend/cache.rs
@@ -200,7 +200,7 @@ mod tests {
 
 	assert_impl_all!(CacheBackend: Backend, Clone, Debug, Default, Send, Sync);
 
-	#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+	#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 	struct Settings {
 		option: bool,
 		times: u32,

--- a/src/backend/cache.rs
+++ b/src/backend/cache.rs
@@ -200,7 +200,9 @@ mod tests {
 
 	assert_impl_all!(CacheBackend: Backend, Clone, Debug, Default, Send, Sync);
 
-	#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+	#[derive(
+		Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+	)]
 	struct Settings {
 		option: bool,
 		times: u32,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -58,7 +58,14 @@ mod tests {
 		}
 	}
 
-	assert_impl_all!(Settings: Clone, Debug, Default, DeserializeOwned, Entry, Serialize);
+	assert_impl_all!(
+		Settings: Clone,
+		Debug,
+		Default,
+		DeserializeOwned,
+		Entry,
+		Serialize
+	);
 
 	#[test]
 	fn to_key() {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -19,9 +19,9 @@ impl<T: ToString> Key for T {
 /// This signifies that the type can be stored within a [`Gateway`].
 ///
 /// [`Gateway`]: crate::Gateway
-pub trait Entry: Clone + Serialize + DeserializeOwned + Debug + Send + Sync {}
+pub trait Entry: Clone + Serialize + DeserializeOwned + Debug + Default + Send + Sync {}
 
-impl<T: Clone + Serialize + DeserializeOwned + Debug + Send + Sync> Entry for T {}
+impl<T: Clone + Serialize + DeserializeOwned + Debug + Default + Send + Sync> Entry for T {}
 
 /// An indexable entry, used for any [`Entry`] that can be indexed by a [`Key`] that it owns.
 pub trait IndexEntry: Entry {
@@ -41,7 +41,7 @@ mod tests {
 
 	use super::{Entry, Key};
 
-	#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+	#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 	struct Settings {
 		id: u32,
 		name: String,
@@ -58,7 +58,7 @@ mod tests {
 		}
 	}
 
-	assert_impl_all!(Settings: Clone, Debug, DeserializeOwned, Entry, Serialize);
+	assert_impl_all!(Settings: Clone, Debug, Default, DeserializeOwned, Entry, Serialize);
 
 	#[test]
 	fn to_key() {


### PR DESCRIPTION
Closes #29 

- [x] Add default bound to Entry
- [x] Add check to Actions to look for specific `"metadata"` key.
- [x] Check against metadata when performing serialization.
- [x] Create metadata entry when creating tables
- [x] Check against metadata entry when creating, getting, or updating entries