### PR TITLE
refactor(fs)!: improve fs backends

### DIFF
--- a/src/backend/bincode.rs
+++ b/src/backend/bincode.rs
@@ -71,7 +71,7 @@ unsafe impl<O: Options + Copy> Sync for BincodeBackend<O> {}
 impl<O: Options + Send + Sync + Copy> FsBackend for BincodeBackend<O> {
 	const EXTENSION: &'static str = "bin";
 
-	fn from_reader<R, T>(&self, rdr: R) -> Result<T, FsError>
+	fn read_data<R, T>(&self, rdr: R) -> Result<T, FsError>
 	where
 		R: io::Read,
 		T: Entry,

--- a/src/backend/fs.rs
+++ b/src/backend/fs.rs
@@ -286,15 +286,13 @@ impl<RW: FsBackend> Backend for RW {
 			let filename = util::filename(id.to_owned(), Self::EXTENSION);
 			let path = util::resolve_path(self.base_directory(), &[table, filename.as_str()]);
 			handle_io_result!(fs::File::open(&path).await, file, {
-				let reader = io::BufReader::<StdFile>::new(file.into_std().await);
-				Ok(Some(self.read_data(reader)?))
+				Ok(Some(self.read_data(file.into_std().await)?))
 			})
 		})
 	}
 
 	fn has<'a>(&'a self, table: &'a str, id: &'a str) -> HasFuture<'a, Self::Error> {
 		Box::pin(async move {
-			// let filename = RW::filename(id);
 			let filename = util::filename(id.to_owned(), Self::EXTENSION);
 			let path = util::resolve_path(self.base_directory(), &[table, filename.as_str()]);
 			handle_io_result!(fs::metadata(&path).await, _val, Ok(true), Ok(false))

--- a/src/backend/fs.rs
+++ b/src/backend/fs.rs
@@ -446,7 +446,6 @@ mod tests {
 
 mod util {
 	use std::{
-		borrow::Cow,
 		ffi::OsStr,
 		path::{Path, PathBuf},
 	};
@@ -465,8 +464,7 @@ mod util {
 						path: path_ref.to_path_buf(),
 					},
 				})
-				.map(OsStr::to_string_lossy)
-				.map(Cow::into_owned)
+				.map(|raw| raw.to_string_lossy().into_owned())
 		} else {
 			Err(FsError {
 				kind: FsErrorType::InvalidFile {

--- a/src/backend/fs.rs
+++ b/src/backend/fs.rs
@@ -182,7 +182,7 @@ pub trait FsBackend: Send + Sync {
 	/// # Errors
 	///
 	/// Implementors should return an error with [`FsError::serialization`] error upon failure.
-	fn from_reader<R, T>(&self, rdr: R) -> Result<T, FsError>
+	fn read_data<R, T>(&self, rdr: R) -> Result<T, FsError>
 	where
 		R: Read,
 		T: Entry;
@@ -287,7 +287,7 @@ impl<RW: FsBackend> Backend for RW {
 			let path = util::resolve_path(self.base_directory(), &[table, filename.as_str()]);
 			handle_io_result!(fs::File::open(&path).await, file, {
 				let reader = io::BufReader::<StdFile>::new(file.into_std().await);
-				Ok(Some(self.from_reader(reader)?))
+				Ok(Some(self.read_data(reader)?))
 			})
 		})
 	}
@@ -441,7 +441,7 @@ mod tests {
 	impl FsBackend for MockFsBackend {
 		const EXTENSION: &'static str = "test";
 
-		fn from_reader<R, T>(&self, _: R) -> Result<T, FsError>
+		fn read_data<R, T>(&self, _: R) -> Result<T, FsError>
 		where
 			R: io::Read,
 			T: Entry,

--- a/src/backend/fs.rs
+++ b/src/backend/fs.rs
@@ -396,7 +396,7 @@ mod util {
 
 		if path_ref.extension().map_or(false, |path| path == extension) {
 			path_ref
-				.file_name()
+				.file_stem()
 				.ok_or(FsError {
 					source: None,
 					kind: FsErrorType::InvalidFile {

--- a/src/backend/json.rs
+++ b/src/backend/json.rs
@@ -37,7 +37,7 @@ impl JsonBackend {
 impl FsBackend for JsonBackend {
 	const EXTENSION: &'static str = "json";
 
-	fn from_reader<R, T>(&self, rdr: R) -> Result<T, FsError>
+	fn read_data<R, T>(&self, rdr: R) -> Result<T, FsError>
 	where
 		R: io::Read,
 		T: Entry,
@@ -90,7 +90,7 @@ impl JsonPrettyBackend {
 impl FsBackend for JsonPrettyBackend {
 	const EXTENSION: &'static str = "json";
 
-	fn from_reader<R, T>(&self, rdr: R) -> Result<T, FsError>
+	fn read_data<R, T>(&self, rdr: R) -> Result<T, FsError>
 	where
 		R: io::Read,
 		T: Entry,

--- a/src/backend/toml.rs
+++ b/src/backend/toml.rs
@@ -37,7 +37,7 @@ impl TomlBackend {
 impl FsBackend for TomlBackend {
 	const EXTENSION: &'static str = "toml";
 
-	fn from_reader<R, T>(&self, mut rdr: R) -> Result<T, FsError>
+	fn read_data<R, T>(&self, mut rdr: R) -> Result<T, FsError>
 	where
 		R: io::Read,
 		T: Entry,
@@ -92,7 +92,7 @@ impl TomlPrettyBackend {
 impl FsBackend for TomlPrettyBackend {
 	const EXTENSION: &'static str = "toml";
 
-	fn from_reader<R, T>(&self, mut rdr: R) -> Result<T, FsError>
+	fn read_data<R, T>(&self, mut rdr: R) -> Result<T, FsError>
 	where
 		R: io::Read,
 		T: Entry,

--- a/src/backend/yaml.rs
+++ b/src/backend/yaml.rs
@@ -35,7 +35,7 @@ impl YamlBackend {
 impl FsBackend for YamlBackend {
 	const EXTENSION: &'static str = "yaml";
 
-	fn from_reader<R, T>(&self, rdr: R) -> Result<T, FsError>
+	fn read_data<R, T>(&self, rdr: R) -> Result<T, FsError>
 	where
 		R: io::Read,
 		T: Entry,


### PR DESCRIPTION
Removes unneeded (and slower) public methods from the FsBackend trait
